### PR TITLE
Put installations in scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Patrick Spek <p.spek@tyil.work>"
 ARG RELEASE=master
 
 # Update shell profile
-COPY ./scripts/profile.sh /etc/profile.d/perl6
-RUN . /etc/profile.d/perl6
+COPY ./scripts/bashrc.sh /root/.bashrc
 
 # Install Rakudo Perl 6
 COPY ./scripts/update-perl6.sh /usr/bin/update-perl6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable
 LABEL maintainer="Patrick Spek <p.spek@tyil.work>"
 
-ARG release=master
+ARG RELEASE=master
 
 # Update shell profile
 COPY ./scripts/profile.sh /etc/profile.d/perl6
@@ -9,7 +9,7 @@ RUN . /etc/profile.d/perl6
 
 # Install Rakudo Perl 6
 COPY ./scripts/update-perl6.sh /usr/bin/update-perl6
-RUN update-perl6 $release
+RUN update-perl6 $RELEASE
 
 # Install zef
 COPY ./scripts/update-zef.sh /usr/bin/update-zef

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ LABEL maintainer="Patrick Spek <p.spek@tyil.work>"
 
 ARG release=master
 
+# Update shell profile
+COPY ./scripts/profile.sh /etc/profile.d/perl6
+RUN . /etc/profile.d/perl6
+
 # Install Rakudo Perl 6
 COPY ./scripts/update-perl6.sh /usr/bin/update-perl6
 RUN update-perl6 $release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,15 @@
 FROM debian:stable
 LABEL maintainer="Patrick Spek <p.spek@tyil.work>"
 
-WORKDIR /perl6
+ARG release=master
 
-# Prepare system
-RUN apt update
-RUN apt -y install build-essential curl git
+# Install Rakudo Perl 6
+COPY ./scripts/update-perl6.sh /usr/bin/update-perl6
+RUN update-perl6 $release
 
-# Setup rakudobrew
-RUN git clone https://github.com/tadzik/rakudobrew
-
-RUN printf "%s\n" 'export PATH=/perl6/rakudobrew/bin:$PATH' >> /etc/profile
-RUN printf "%s\n" 'eval "$(/perl6/rakudobrew/bin/rakudobrew init -)"' >> /etc/profile
-
-ENV PATH="/perl6/rakudobrew/bin:${PATH}"
-
-# Compile Rakudo Perl 6
-RUN rakudobrew build moar 2018.01
-RUN rakudobrew build zef
-RUN rakudobrew rehash
-
-# Install nice things
-RUN zef install Test::META
-
-# Cleanup system
-RUN apt -y remove build-essential
-RUN apt -y autoremove
+# Install zef
+COPY ./scripts/update-zef.sh /usr/bin/update-zef
+RUN update-zef
 
 # Prepare for use as a base template
 WORKDIR /app

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-docker:
-	docker build -t scriptkitties/perl6:2018.01 .

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,40 @@
+= scriptkitties/perl6
+
+A docker image containing https://perl6.org[Perl 6].
+
+== Usage
+To get the docker image, `pull` it using `docker`:
+
+[source,sh]
+----
+$ docker pull scriptkitties/perl6:latest
+----
+
+There are also versioned releases available, which follow the versioning of the
+Perl 6 releases. To get these, replace the `latest` tag with the release
+number:
+
+[source,sh]
+----
+$ docker pull scriptkitties/perl6:2018.01
+----
+
+== Building the image
+If you want to build this image yourself, the easiest way is to use the
+`build.sh` script supplied in the root of the repository. To build the latest
+Perl 6 release, run it without arguments:
+
+[source,sh]
+----
+$ sh ./build.sh
+----
+
+If you want a specific release, pass this as an argument:
+
+[source,sh]
+----
+$ sh ./build.sh 2018.01
+----
+
+== License
+All code supplied in this repository is distributed under the LGPL version 3.

--- a/build.sh
+++ b/build.sh
@@ -5,9 +5,16 @@ main()
 	release=${1:-master}
 	tag=${1:-latest}
 
+	[ -n "$1" ] && args=" --no-cache"
+
+	shift
+
+	args="$args $*"
+
 	docker build \
 		-t "scriptkitties/perl6:$tag" \
 		--build-arg "RELEASE=$release" \
+		$args \
 		.
 }
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env sh
+
+main()
+{
+	release=${1:-master}
+	tag=${1:-latest}
+
+	docker build \
+		-t "scriptkitties/perl6:$tag" \
+		--build-arg "RELEASE=$release" \
+		.
+}
+
+main "$@"

--- a/scripts/bashrc.sh
+++ b/scripts/bashrc.sh
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+
+# Extend path for Perl 6 modules
+export PATH="/usr/local/share/perl6/site/bin:$PATH"

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,3 +1,0 @@
-#! /usr/bin/sh
-
-export PATH="/usr/local/share/perl6/site/bin:$PATH"

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/sh
+
+export PATH="/usr/local/share/perl6/site/bin:$PATH"

--- a/scripts/update-perl6.sh
+++ b/scripts/update-perl6.sh
@@ -1,0 +1,40 @@
+#! /usr/bin/env sh
+
+readonly DEPS="build-essential git"
+readonly WORKDIR=$(mktemp -d)
+
+build()
+{
+	perl Configure.pl --gen-moar --gen-nqp --backends=moar --prefix=/usr/local
+	make
+	make install
+}
+
+cleanup()
+{
+	rm -rf "$WORKDIR"
+	apt remove $DEPS
+	apt autoremove
+}
+
+prepare()
+{
+	apt update
+	apt install -y $DEPS
+
+	git clone https://github.com/rakudo/rakudo/ "$WORKDIR"
+	cd "$WORKDIR" || exit
+
+	git checkout "$1"
+	git pull
+}
+
+main()
+{
+	prepare "${1:-master}"
+	build
+	perl6 --version
+	cleanup
+}
+
+main "$@"

--- a/scripts/update-perl6.sh
+++ b/scripts/update-perl6.sh
@@ -13,8 +13,8 @@ build()
 cleanup()
 {
 	rm -rf "$WORKDIR"
-	apt remove $DEPS
-	apt autoremove
+	apt -y remove $DEPS
+	apt -y autoremove
 }
 
 prepare()

--- a/scripts/update-zef.sh
+++ b/scripts/update-zef.sh
@@ -26,13 +26,13 @@ prepare()
 
 main()
 {
-	# Curl is needed in order to use zef
-	apt install curl
-
 	# Bootstrap zef
 	prepare
 	build
 	cleanup
+
+	# Curl is needed in order to use zef
+	apt install curl
 }
 
 main "$@"

--- a/scripts/update-zef.sh
+++ b/scripts/update-zef.sh
@@ -11,8 +11,8 @@ build()
 cleanup()
 {
 	rm -rf "$WORKDIR"
-	apt remove $DEPS
-	apt autoremove
+	apt -y remove $DEPS
+	apt -y autoremove
 }
 
 prepare()
@@ -32,7 +32,7 @@ main()
 	cleanup
 
 	# Curl is needed in order to use zef
-	apt install curl
+	apt install -y curl
 }
 
 main "$@"

--- a/scripts/update-zef.sh
+++ b/scripts/update-zef.sh
@@ -1,0 +1,38 @@
+#! /usr/bin/env sh
+
+readonly DEPS="git"
+readonly WORKDIR=$(mktemp -d)
+
+build()
+{
+	perl6 -I. bin/zef install .
+}
+
+cleanup()
+{
+	rm -rf "$WORKDIR"
+	apt remove $DEPS
+	apt autoremove
+}
+
+prepare()
+{
+	apt update
+	apt install -y $DEPS
+
+	git clone https://github.com/ugexe/zef "$WORKDIR"
+	cd "$WORKDIR" || exit
+}
+
+main()
+{
+	# Curl is needed in order to use zef
+	apt install curl
+
+	# Bootstrap zef
+	prepare
+	build
+	cleanup
+}
+
+main "$@"


### PR DESCRIPTION
This (greatly) reduces the size of the resulting image, and allows us to easily follow upstream without depending on Rakudobrew.